### PR TITLE
Add BLE communication logger

### DIFF
--- a/BleLogger.kt
+++ b/BleLogger.kt
@@ -1,0 +1,28 @@
+package com.soflow.ble
+
+import android.content.Context
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Utility object for logging raw BLE messages to a text file.
+ * Each log entry includes a timestamp and the message bytes formatted as hex.
+ */
+object BleLogger {
+    private const val LOG_FILE_NAME = "ble_log.txt"
+    private val timeFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+    /**
+     * Appends the provided [data] to the log file. The file is stored in the app's
+     * external files directory when available, falling back to internal storage.
+     */
+    fun log(context: Context, data: ByteArray) {
+        val dir = context.getExternalFilesDir(null) ?: context.filesDir
+        val logFile = File(dir, LOG_FILE_NAME)
+        val timestamp = timeFormat.format(Date())
+        val hex = data.joinToString(separator = " ") { String.format("%02X", it) }
+        logFile.appendText("$timestamp: $hex\n")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # SoFlowUnchained
 Android app for SoFlow SO2 Air Gen 2. Connects via Bluetooth Low Energy to send predefined hex commands. Buttons for 20/27 km/h, ECO, Normal, Sport, and Lock/Unlock. 100% local, no server, no tracking. For tinkerers only – use at your own risk.
+
+See [SPEC.md](SPEC.md) for the full project specification.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,72 @@
+# SO2 Air Codex Specification
+
+## Project
+- **Project**: SO2 Air Codex
+- **Version**: 1.0.0
+- **Date**: 2025-08-19
+- **Owner**: Roland Mitterbauer
+- **Platform**: Android API 29–34
+- **Scope**: BLE app to control the SoFlow SO2 Air Gen 2 scooter using predefined hex commands.
+
+## Features
+- BLE scan, connect, and automatic reconnect
+- Handshake: Secret → Connect → optional Unlock
+- Buttons: 20 km/h, 27 km/h, ECO, NORMAL, SPORT, LOCK, UNLOCK
+- Hex logging with timestamps and export
+- Configurable UUIDs, delays, and profiles
+- Warning dialog before selecting speeds above 20 km/h
+- English-only UI and code comments
+
+## BLE
+- Service UUID: `0000FFF0-0000-1000-8000-00805F9B34FB`
+- Write UUID: `0000FFF1-0000-1000-8000-00805F9B34FB`
+- Write type: `WRITE_NO_RESPONSE`
+- MTU: 247
+- Write delay: 100 ms
+- Retries: 2 with backoff 250 ms, 500 ms
+
+## Communication Protocol
+- Secret code: `5A`
+- Handshake: [`5A`, `D707A05A00012`]
+- Commands:
+  - Unlock: `D707A25A00003`
+  - Lock: `D707A25A00014`
+  - ECO: `D707A45A00005`
+  - NORMAL: `D707A45A00016`
+  - SPORT: `D707A25A00027`
+  - Speed 20 km/h (preferred): `D707A90000C878`
+  - Speed 20 km/h (alternate): `D707A90000C868`
+  - Speed 27 km/h: `D707A900010EAF`
+
+## UI
+- Screens: Scan, Control, Settings, Logs
+- Controls: BTN_20, BTN_27, BTN_ECO, BTN_NORMAL, BTN_SPORT, BTN_LOCK, BTN_UNLOCK
+- States: DISCONNECTED, CONNECTING, HANDSHAKING, READY, ERROR
+
+## Flows
+- **Set_20kmh**: SECRET → HANDSHAKE → UNLOCK → SPEED_20_PREF (fallback: SECRET → HANDSHAKE → UNLOCK)
+- **Set_27kmh**: SECRET → HANDSHAKE → UNLOCK → SPEED_27
+- **Mode_ECO**: SECRET → HANDSHAKE → ECO
+- **Mode_NORMAL**: SECRET → HANDSHAKE → NORMAL
+- **Mode_SPORT**: SECRET → HANDSHAKE → SPORT
+- **Lock**: SECRET → HANDSHAKE → LOCK
+- **Unlock**: SECRET → HANDSHAKE → UNLOCK
+
+## Validation
+- **Success criteria**:
+  - Command acknowledged <2 s
+  - Five consecutive actions without error
+  - No crashes during 15 min runtime
+- **Negative tests**:
+  - Device out of range
+  - Write timeout
+  - Firmware ignores speed override
+
+## Legal
+- Disclaimer: Use at your own risk. Respect local speed limits.
+- Telemetry: No servers, no tracking, everything local.
+
+## Risks
+- Different UUIDs/checksums per firmware
+- Controller blocks commands while driving
+- Android BLE stack incompatibilities on some phones


### PR DESCRIPTION
## Summary
- add utility to log BLE message bytes with timestamps to a text file
- document project specification and reference it from the README

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a474e0b19c8333aea33c3c43c3f7da