### PR TITLE
Enable AndroidX and Java 8 compilation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,13 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14"
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -46,6 +53,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.navigation:navigation-compose:2.8.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.1")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.1")

--- a/app/src/main/java/com/rolandmit/so2aircodex/MainActivity.kt
+++ b/app/src/main/java/com/rolandmit/so2aircodex/MainActivity.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Build
-import androidx.compose.material.icons.filled.List as ListIcon
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -55,7 +55,7 @@ fun BottomBar(nav: NavHostController) {
         NavigationBarItem(selected = false, onClick = { nav.navigate("scan") }, label = { Text("Scan") }, icon = { Icon(Icons.Filled.Bluetooth, null) })
         NavigationBarItem(selected = false, onClick = { nav.navigate("control") }, label = { Text("Control") }, icon = { Icon(Icons.Filled.Build, null) })
         NavigationBarItem(selected = false, onClick = { nav.navigate("settings") }, label = { Text("Settings") }, icon = { Icon(Icons.Filled.Settings, null) })
-        NavigationBarItem(selected = false, onClick = { nav.navigate("logs") }, label = { Text("Logs") }, icon = { Icon(ListIcon, null) })
+        NavigationBarItem(selected = false, onClick = { nav.navigate("logs") }, label = { Text("Logs") }, icon = { Icon(Icons.Filled.List, null) })
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application") version "8.5.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,7 @@
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
 
 org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+android.useAndroidX=true
+kotlin.jvmTarget=1.8
 


### PR DESCRIPTION
## Summary
- enable AndroidX support and Java 8 toolchain
- bump Kotlin plugin to 1.9.24 and add compose icon dependency
- fix MainActivity material icon usage

## Testing
- `./gradlew clean --console=plain`
- `./gradlew assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68a8359646e483338242e580b95a041d